### PR TITLE
el-button升级成element-plus用法

### DIFF
--- a/src/views/accounting/index.vue
+++ b/src/views/accounting/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { AccountingRecord, CreateAccountingInput } from '@/api/index'
+import { Plus, Refresh } from '@element-plus/icons-vue'
 import { ElMessage, ElMessageBox } from 'element-plus'
 import { computed, onMounted, ref } from 'vue'
 import { createAccounting, deleteAccounting, queryAccountingList } from '@/api/index'
@@ -165,13 +166,13 @@ onMounted(() => {
       <div class="action-right">
         <el-button
           type="default"
-          icon="el-icon-refresh"
+          :icon="Refresh"
           :loading="loading"
           @click="handleRefresh"
         >
           刷新
         </el-button>
-        <el-button type="primary" icon="el-icon-plus" @click="handleAdd">
+        <el-button type="primary" :icon="Plus" @click="handleAdd">
           新增记账
         </el-button>
       </div>


### PR DESCRIPTION
element-plus使用icon方式改变

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches el-button icon props to use Element Plus icon components on the accounting page.
> 
> - **Frontend**
>   - **Accounting page** (`src/views/accounting/index.vue`):
>     - Import `Plus` and `Refresh` from `@element-plus/icons-vue`.
>     - Replace `icon="el-icon-refresh"` and `icon="el-icon-plus"` with `:icon="Refresh"` and `:icon="Plus"` on `el-button`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2f4415ca4042a9e90cf32eaf3cfbfb1ebd4651b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->