### PR TITLE
feat: 路由用的是history，所以需要排除api

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -35,6 +35,15 @@ module.exports = defineConfig({
     client: {
       webSocketURL: 'ws://0.0.0.0:8080/ws',
     },
+    // 配置 historyApiFallback，排除 /api 路径，确保 API 请求走代理
+    historyApiFallback: {
+      disableDotRule: true,
+      // 只对非 API 路径进行路由回退
+      rewrites: [
+        { from: /^\/api/, to: false }, // 排除 /api 路径，不走 historyApiFallback
+        { from: /./, to: '/index.html' }, // 其他路径回退到 index.html
+      ],
+    },
     proxy: {
       '/api': {
         target: 'https://feng-fortitude.com',


### PR DESCRIPTION
修复api/accounting会被匹配到路由

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Configure devServer history fallback to ignore /api so API requests use the proxy while other routes fallback to index.html.
> 
> - **Dev Server (vue.config.js)**:
>   - Add `historyApiFallback` with `rewrites` to exclude `^/api` and route other paths to `/index.html`.
>   - Preserve `/api` proxy to `https://feng-fortitude.com` with `changeOrigin: true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d39b8ef874b9804579f9860a106b35f7a61f0bb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->