### PR TITLE
Page layout zoom issue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,7 @@
   text-align: left;
 }
 
+html,
 body {
   margin: 0;
   background-color: #f6f8fb;


### PR DESCRIPTION
Set `html` and `body` background color to `#f6f8fb` to prevent visible borders when zooming.

When the browser is zoomed in, content can overflow the fixed-height `#app` container, revealing the `html` element's background. Previously, the `html` element had a different background color, causing a visible "white" (light grey) border. This change ensures a consistent background across the entire scrollable area.

---
<a href="https://cursor.com/background-agent?bcId=bc-007a08da-22b2-4667-b0a2-0db23a054545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-007a08da-22b2-4667-b0a2-0db23a054545"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

